### PR TITLE
changes: customization of requirements.txt file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,20 @@ Github Action to integrate Coverage.py with Django on every pull request. It com
 
 ## Inputs
 
-### `django-app`
+### `django-apps`
 
-The name of the Django app.
+The name of the Django app or a comma separated list of Django apps you would like to cover `app1,app2`.
 Default:
 
 ### `minimum-coverage`
 
 Percentage of required coverage to consider it a valid commit.
 Default: `10`
+
+### `requirements-txt`
+
+Path to the requirements.txt file.
+Default: `requirements.txt`
 
 ## Outputs
 
@@ -22,8 +27,8 @@ Boolean value that indicates that the test run and coverage was successful.
 
 ## Example usage
 
-    uses: actions/checkout@v2
-    uses: actions/python-django-coverage-gitHub-action@v1
+    uses: tadomikikuto-bit/python-django-coverage-gitHub-action@master
     with:
-      django-app: 'sample_app'
+      django-apps: 'sample_app'
       minimum-coverage: '86'
+      requirements-txt: 'requirements.txt'

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,17 @@
 name: Python Django Coverage GitHub Action
 inputs:
-  django-app:
-    description: "Application"
+  django-apps:
+    description: "Application(s)"
     required: false
     default: ""
   minimum-coverage:
     description: "Minimum allowed code coverage"
     required: false
-    default: "10"  
+    default: "10"
+  requirements-txt:
+    description: "Path to the requirements.txt file"
+    required: false
+    default: "requirements.txt"
 description: 'Github Action to run tests and get coverage with Django on a Python Docker image'
 branding:
   icon: box
@@ -17,5 +21,6 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-  - ${{ inputs.django-app }}
+  - ${{ inputs.django-apps }}
   - ${{ inputs.minimum-coverage }}
+  - ${{ inputs.requirements-txt }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,20 +5,21 @@ echo "#################################################"
 echo "Starting ${GITHUB_WORKFLOW}:${GITHUB_ACTION}"
 
 
-APP=$1
+APPS=$1
 MIN_COVERAGE=$2
+REQUIREMENTS_TEXT=$3
 
 # start PostgreSQL
 service postgresql start
 
 # setup run settings
-if [ -z "${APP}" ]; then
-    # coverage on everything when app is empty
+if [ -z "${APPS}" ]; then
+    # coverage on everything when APPS is empty
     APP_LOCATION="."
     VENV_NAME="virtenv1"
 else
-    APP_LOCATION=$APP
-    VENV_NAME=virtenv_$APP
+    APP_LOCATION=$APPS
+    VENV_NAME=virtenv_$APPS
 fi
 
 # init virtual environment
@@ -28,13 +29,16 @@ fi
 
 source "${GITHUB_WORKSPACE}/${VENV_NAME}/bin/activate"
 
-pip install -r requirements.txt
+# upgrade pip to the latest version
+python -m pip install --upgrade pip
+
+pip install -r $REQUIREMENTS_TEXT
 
 echo "Base setup complete. Setting up a sample DB url and running..."
 export DATABASE_URL='postgresql://ctest:coveragetest123@127.0.0.1:5432/demo'
 
 # This will automatically fail (set -e is set by default) if the tests fail, which is OK.
-coverage run --source "${APP_LOCATION}" manage.py test "${APP}"
+coverage run --source="${APP_LOCATION}" -m pytest
 
 # Now get the coverage
 COVERAGE_RESULT=`coverage report | grep TOTAL | awk 'N=1 {print $NF}' | sed 's/%//g'`


### PR DESCRIPTION
1. actions.yml
specify the new input name and change `django-app` to `django-apps`
to convey that it can take a list of apps

2. entrypoint.sh
change `APP` to `APPS` to convey that it can take a list of apps,
customize the coverage command to work with pytest instead and lastly
change the installation command to take the requirements.txt path file
from the input

3. README.md
reflect the changes made in other files